### PR TITLE
Improve withinSessionLevelLock: invoke callback only on successful lo…

### DIFF
--- a/src/Postgres/LockHandle/WithinSessionLevelLockHandle.php
+++ b/src/Postgres/LockHandle/WithinSessionLevelLockHandle.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of PHP DB Locker.
+ *
+ * (c) Anton Komarev <anton@komarev.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Cog\DbLocker\Postgres\LockHandle;
+
+/**
+ * @template TReturn
+ */
+final class WithinSessionLevelLockHandle
+{
+    /**
+     * @param TReturn $result
+     */
+    public function __construct(
+        public readonly bool $wasAcquired,
+        public readonly mixed $result,
+    ) {}
+}

--- a/src/Postgres/PostgresAdvisoryLocker.php
+++ b/src/Postgres/PostgresAdvisoryLocker.php
@@ -73,6 +73,9 @@ final class PostgresAdvisoryLocker
      *
      * @throws LockAcquireException If a database error occurs during lock acquisition. NOT thrown for normal lock contention.
      * @throws LockReleaseException If a database error occurs during lock release (only thrown if no other exception occurred during callback execution).
+     *     ⚠️ A LockReleaseException guarantees that the callback has completed successfully,
+     *     but the callback's return value is lost. If you need access to the callback result
+     *     in this scenario, use acquireSessionLevelLock() / releaseSessionLevelLock() directly.
      *
      * @see acquireTransactionLevelLock() for preferred locking strategy.
      *

--- a/test/Integration/Postgres/PostgresAdvisoryLockerTest.php
+++ b/test/Integration/Postgres/PostgresAdvisoryLockerTest.php
@@ -843,7 +843,7 @@ final class PostgresAdvisoryLockerTest extends AbstractIntegrationTestCase
         $y = 3;
 
         // WHEN: Executing code within a session-level lock using callback
-        $result = $locker->withinSessionLevelLock(
+        $handle = $locker->withinSessionLevelLock(
             new PdoConnectionAdapter($dbConnection),
             $lockKey,
             function () use ($dbConnection, $lockKey, $accessMode, $x, $y): int {
@@ -857,7 +857,8 @@ final class PostgresAdvisoryLockerTest extends AbstractIntegrationTestCase
         );
 
         // THEN: Callback should execute successfully and lock should be auto-released
-        $this->assertSame(5, $result);
+        $this->assertTrue($handle->wasAcquired);
+        $this->assertSame(5, $handle->result);
         $this->assertPgAdvisoryLocksCount(0);
         $this->assertPgAdvisoryLockMissingInConnection($dbConnection, $lockKey);
     }
@@ -902,11 +903,13 @@ final class PostgresAdvisoryLockerTest extends AbstractIntegrationTestCase
             // THEN: The original exception from callback should be preserved, not masked by release failure
             $this->assertSame('Original error from callback', $e->getMessage());
         } catch (\PDOException $e) {
-            $this->fail('PDOException from release should not mask the original RuntimeException: ' . $e->getMessage());
+            $this->fail(
+                'PDOException from release should not mask the original RuntimeException: ' . $e->getMessage(),
+            );
         }
     }
 
-    public function testWithinSessionLevelLockDoesNotReleaseWhenLockWasNotAcquired(): void
+    public function testWithinSessionLevelLockDoesNotCallCallbackWhenLockWasNotAcquired(): void
     {
         // GIVEN: A lock already held by another connection so the second cannot acquire it
         $locker = $this->initLocker();
@@ -918,17 +921,22 @@ final class PostgresAdvisoryLockerTest extends AbstractIntegrationTestCase
             $lockKey,
             TimeoutDuration::zero(),
         );
+        $callbackExecuted = false;
 
         // WHEN: withinSessionLevelLock is called on second connection (lock not acquired)
-        $locker->withinSessionLevelLock(
+        $handle = $locker->withinSessionLevelLock(
             new PdoConnectionAdapter($dbConnection2),
             $lockKey,
-            function ($lockHandle): void {
-                $this->assertFalse($lockHandle->wasAcquired);
+            function () use (&$callbackExecuted): void {
+                $callbackExecuted = true;
             },
             TimeoutDuration::zero(),
         );
 
+        // THEN: Callback should not be called, handle should indicate lock was not acquired
+        $this->assertFalse($handle->wasAcquired);
+        $this->assertNull($handle->result);
+        $this->assertFalse($callbackExecuted);
         // THEN: The first connection's lock should still be intact (not decremented by a spurious release)
         $this->assertPgAdvisoryLocksCount(1);
         $this->assertPgAdvisoryLockExistsInConnection($dbConnection1, $lockKey);


### PR DESCRIPTION
This PR improves the `withinSessionLevelLock()` API by invoking the callback **only** when the lock is successfully acquired, eliminating the need for manual `wasAcquired` checks inside the callback.

### Before
```php
$result = $locker->withinSessionLevelLock($conn, $key, function ($handle) {
    if (!$handle->wasAcquired) {
        return null; // Consumer must check inside callback
    }
    return processOrder();
}, $timeout);

### After
```php
$handle = $locker->withinSessionLevelLock($conn, $key, fn() => processOrder(), $timeout);

if ($handle->wasAcquired) {
    echo $handle->result; // Result of callback
} else {
    // Lock not acquired, callback was not invoked
}
```

### Key improvements

1. **Callback only on success** — The callback is invoked only when the lock is acquired. If the lock is held by another process, the callback is skipped and `wasAcquired = false`.

2. **Cleaner API** — Consumer checks `wasAcquired` outside the callback, not inside. The callback can focus solely on the critical section logic.

3. **New return type** — Returns `WithinSessionLevelLockHandle` with:
   - `wasAcquired: bool` — Whether the lock was acquired
   - `result: mixed` — Result of the callback (null if lock not acquired)

4. **Simpler callback signature** — Callback no longer receives `SessionLevelLockHandle` argument, since it's only invoked when the lock is held.
